### PR TITLE
New query results and queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,13 @@ docker stop blazegraph
 this will delete the instance and remove all the data. go back to step 1 to restart.
 
 
+### Querying from the command line
+```
+$ curl -X POST --data-binary '@queries/simple2_query_participants.sparql' \
+ -H 'Content-Type: application/sparql-query' -H 'Accept: text/csv' \
+ http://localhost:8889/bigdata/sparql > result_participants.csv
+```
+
 ### Simple 2 SPARQL Query (using PyNIDM, running time TOO LONG for > 10 files):
 This query will return study name, participant ID, age, diagnosis, gender, FIQ, PIQ, VIQ, and brain volume data.  It depends on NIDM files that include all of this information. The examples from ABIDE and ADHD200 have been converted to NIDM in 3 steps: (1) BIDS2MRI to get metadata about project information; (2) CSV2NIDM to convert/annotate assessment and demographics information (i.e. age, gender, diagnosis, FIQ, ...) (3) Exported brain volume data from ANTS, FSL, and Freesurfer using https://github.com/dbkeator/ants_seg_to_nidm, https://github.com/dbkeator/fsl_seg_to_nidm, and https://github.com/dbkeator/segstats_jsonld/ respectively.  The simple_2_NIDM_examples repo has some helper scripts for the brain volume stuff on a large scale (see add_freesurfer_asegvols.py, add_fsl_segvols.py, and add_fsl_segvols.py).
 

--- a/queries/simple2_query_participants.sparql
+++ b/queries/simple2_query_participants.sparql
@@ -1,0 +1,48 @@
+prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+prefix prov: <http://www.w3.org/ns/prov#>
+prefix ndar: <https://ndar.nih.gov/api/datadictionary/v2/dataelement/>
+prefix fsl: <http://purl.org/nidash/fsl#>
+prefix nidm: <http://purl.org/nidash/nidm#>
+prefix onli: <http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#>
+prefix freesurfer: <https://surfer.nmr.mgh.harvard.edu/>
+prefix dx: <http://ncitt.ncit.nih.gov/Diagnosis>
+prefix ants: <http://stnava.github.io/ANTs/> 
+prefix dct: <http://purl.org/dc/terms/>
+prefix dctypes: <http://purl.org/dc/dcmitype/>
+prefix ncicb: <http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#>
+prefix ncit: <http://ncitt.ncit.nih.gov/>
+
+select distinct ?study ?ID ?Age ?dx ?Gender ?FIQ
+where {
+			?as_activity prov:qualifiedAssociation [prov:agent ?agent] ; 
+					dct:isPartOf/dct:isPartOf [dctypes:title ?study] .
+			?agent ndar:src_subject_id ?ID .
+				
+			
+			# find age data element uuid
+			{?age_measure a nidm:DataElement ;
+					nidm:isAbout ncicb:Age .
+			}
+			# find sex data element uuid
+			{?sex_measure a nidm:DataElement ;
+					nidm:isAbout ndar:gender .
+			}
+			# find diagnosis data element uuid
+			{?DX_measure a nidm:DataElement ;
+					nidm:isAbout ncit:Diagnosis .
+			
+			}
+			# find fiq data element uuid
+  			{?FIQ_measure a nidm:DataElement ;
+					nidm:isAbout <https://github.com/dbkeator/nidm-local-terms/issues/2> .
+			}			
+  			?as_entity prov:wasGeneratedBy ?as_activity ;
+	        	?age_measure ?Age;
+	        	?sex_measure ?GenderCoded ;
+                ?FIQ_measure ?FIQ ;
+            	?DX_measure ?dx .
+			
+			bind(IF((?GenderCoded ="1" || ?GenderCoded ="Male"^^xsd:string), "Male"^^xsd:string,"Female"^^xsd:string) as ?Gender) .
+} order by ?study
+
+

--- a/queries/simple2_query_volmeasures.sparql
+++ b/queries/simple2_query_volmeasures.sparql
@@ -1,0 +1,38 @@
+prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+prefix prov: <http://www.w3.org/ns/prov#>
+prefix ndar: <https://ndar.nih.gov/api/datadictionary/v2/dataelement/>
+prefix fsl: <http://purl.org/nidash/fsl#>
+prefix nidm: <http://purl.org/nidash/nidm#>
+prefix onli: <http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#>
+prefix freesurfer: <https://surfer.nmr.mgh.harvard.edu/>
+prefix dx: <http://ncitt.ncit.nih.gov/Diagnosis>
+prefix ants: <http://stnava.github.io/ANTs/>
+prefix dct: <http://purl.org/dc/terms/>
+prefix dctypes: <http://purl.org/dc/dcmitype/>
+prefix ncicb: <http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#>
+prefix ncit: <http://ncitt.ncit.nih.gov/>
+
+
+select distinct ?study ?ID ?tool ?softwareLabel ?federatedLabel ?laterality ?volume
+where {
+			?as_activity prov:qualifiedAssociation [prov:agent ?agent] ;
+					dct:isPartOf/dct:isPartOf [dctypes:title ?study] .
+			FILTER REGEX(STR(?study), "(^AB)")
+			?agent ndar:src_subject_id ?ID .
+
+            ?measure a/rdfs:subClassOf nidm:DataElement;
+                 rdfs:label ?softwareLabel;
+                 nidm:measureOf <http://uri.interlex.org/base/ilx_0112559> ;
+                 nidm:datumType <http://uri.interlex.org/base/ilx_0738276> .
+            OPTIONAL {?measure nidm:isAbout ?federatedLabel }.
+            OPTIONAL {?measure nidm:hasLaterality ?laterality }.
+
+            ?tool_entity a prov:Entity;
+                ?measure ?volume .
+
+            ?tool_act a prov:Activity ;
+                    prov:qualifiedAssociation [prov:agent [nidm:NIDM_0000164 ?tool]] ;
+                    prov:qualifiedAssociation [prov:agent [ndar:src_subject_id ?ID]] .
+            ?tool_entity prov:wasGeneratedBy ?tool_act .
+
+} order by ?study


### PR DESCRIPTION
@jbpoline - see if the new simple2_query_outputs2.csv works for you.

@dbkeator - i added two different queries, ran them and combined the results with pandas. the two queries separate out the clinical piece from the imaging piece. otherwise, at least my blazegraph instance was running out of memory, and i didn't have the patience to check if this was a java heap problem.

for the imaging piece,  `simple2_query_volmeasures.sparql` i used a filter to restrict the query to either ABIDE or ADHD.  and i ran it twice with 'AB' and 'AD' as filters.

obviously this is not a long term solution, but i wanted to get something to jb.
